### PR TITLE
Show student course total grade

### DIFF
--- a/flask_backend/api/controllers/class_controller.py
+++ b/flask_backend/api/controllers/class_controller.py
@@ -3,6 +3,7 @@ from flask_jwt_extended import get_jwt_identity, jwt_required
 from werkzeug.security import generate_password_hash
 
 from ..models import Course, User, User_Course
+from ..services import calculate_student_course_total_grade
 from .auth_controller import jwt_teacher_required
 import re
 import csv
@@ -66,7 +67,18 @@ def get_user_classes():
     else:
         courses = []
 
-    return jsonify([{"id": c.id, "name": c.name} for c in courses]), 200
+    payload = []
+    for course in courses:
+        if not course:
+            continue
+
+        row = {"id": course.id, "name": course.name}
+        if user.is_student():
+            row["total_grade"] = calculate_student_course_total_grade(user.id, course.id)
+
+        payload.append(row)
+
+    return jsonify(payload), 200
 
 
 @bp.route("/members", methods=["POST"])

--- a/flask_backend/api/services/__init__.py
+++ b/flask_backend/api/services/__init__.py
@@ -1,0 +1,3 @@
+from .course_grade_service import calculate_student_course_total_grade
+
+__all__ = ["calculate_student_course_total_grade"]

--- a/flask_backend/api/services/course_grade_service.py
+++ b/flask_backend/api/services/course_grade_service.py
@@ -1,0 +1,31 @@
+from ..models import Assignment, CriteriaDescription, Criterion, Review, db
+
+
+def calculate_student_course_total_grade(student_id: int, course_id: int):
+    """Return student's total grade percentage for a course or None if unavailable."""
+    rows = (
+        db.session.query(Criterion.grade, CriteriaDescription.scoreMax)
+        .join(Review, Review.id == Criterion.reviewID)
+        .join(Assignment, Assignment.id == Review.assignmentID)
+        .join(CriteriaDescription, CriteriaDescription.id == Criterion.criterionRowID)
+        .filter(
+            Assignment.courseID == course_id,
+            Review.revieweeID == student_id,
+            CriteriaDescription.hasScore.is_(True),
+            Criterion.grade.isnot(None),
+            CriteriaDescription.scoreMax.isnot(None),
+            CriteriaDescription.scoreMax > 0,
+        )
+        .all()
+    )
+
+    if not rows:
+        return None
+
+    earned_points = sum(int(grade) for grade, _ in rows)
+    possible_points = sum(int(score_max) for _, score_max in rows)
+
+    if possible_points <= 0:
+        return None
+
+    return round((earned_points / possible_points) * 100, 1)

--- a/flask_backend/tests/test_course_grades.py
+++ b/flask_backend/tests/test_course_grades.py
@@ -1,0 +1,136 @@
+"""Tests for student course total grade behavior on class listing endpoints."""
+
+import json
+
+from api.models import Assignment, Course, CriteriaDescription, Criterion, Review, Rubric
+from api.models.db import db as _db
+
+
+def _seed_student_course_grade_data(test_client, make_admin, enroll_user_in_course, grade_value=None):
+    teacher = make_admin(
+        email="teacher-grade@example.com",
+        password="Password123!",
+        name="teacher",
+    )
+
+    test_client.post(
+        "/auth/register",
+        data=json.dumps(
+            {"name": "reviewer", "password": "Password123!", "email": "reviewer-grade@example.com"}
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+    reviewer_login = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "reviewer-grade@example.com", "password": "Password123!"}),
+        headers={"Content-Type": "application/json"},
+    )
+    reviewer_id = reviewer_login.json["id"]
+
+    test_client.post(
+        "/auth/register",
+        data=json.dumps(
+            {"name": "student", "password": "Password123!", "email": "student-grade@example.com"}
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+    reviewee_login = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "student-grade@example.com", "password": "Password123!"}),
+        headers={"Content-Type": "application/json"},
+    )
+    reviewee_id = reviewee_login.json["id"]
+
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "teacher-grade@example.com", "password": "Password123!"}),
+        headers={"Content-Type": "application/json"},
+    )
+    class_response = test_client.post(
+        "/class/create_class",
+        data=json.dumps({"name": "Calculus 101"}),
+        headers={"Content-Type": "application/json"},
+    )
+    course_id = class_response.json["class"]["id"]
+
+    enroll_user_in_course(user_id=reviewer_id, course_id=course_id)
+    enroll_user_in_course(user_id=reviewee_id, course_id=course_id)
+
+    course = Course.get_by_id(course_id)
+
+    assignment = Assignment(courseID=course.id, name="Limits", rubric_text="")
+    _db.session.add(assignment)
+    _db.session.commit()
+
+    rubric = Rubric(assignmentID=assignment.id, canComment=True)
+    _db.session.add(rubric)
+    _db.session.commit()
+
+    criterion_row = CriteriaDescription(
+        rubricID=rubric.id,
+        question="Mathematical correctness",
+        scoreMax=5,
+        hasScore=True,
+    )
+    _db.session.add(criterion_row)
+    _db.session.commit()
+
+    review = Review(assignmentID=assignment.id, reviewerID=reviewer_id, revieweeID=reviewee_id)
+    _db.session.add(review)
+    _db.session.commit()
+
+    criterion = Criterion(reviewID=review.id, criterionRowID=criterion_row.id, grade=grade_value)
+    _db.session.add(criterion)
+    _db.session.commit()
+
+    return {
+        "reviewee_email": "student-grade@example.com",
+        "course": course,
+    }
+
+
+def test_get_courses_for_student_includes_total_grade_when_available(
+    test_client, make_admin, enroll_user_in_course
+):
+    seeded = _seed_student_course_grade_data(
+        test_client,
+        make_admin,
+        enroll_user_in_course,
+        grade_value=4,
+    )
+
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": seeded["reviewee_email"], "password": "Password123!"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    response = test_client.get("/class/classes", headers={"Content-Type": "application/json"})
+    assert response.status_code == 200
+
+    course_payload = next(c for c in response.json if c["id"] == seeded["course"].id)
+    assert course_payload["name"] == seeded["course"].name
+    assert course_payload["total_grade"] == 80.0
+
+
+def test_get_courses_for_student_marks_total_grade_unavailable_when_missing(
+    test_client, make_admin, enroll_user_in_course
+):
+    seeded = _seed_student_course_grade_data(
+        test_client,
+        make_admin,
+        enroll_user_in_course,
+        grade_value=None,
+    )
+
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": seeded["reviewee_email"], "password": "Password123!"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    response = test_client.get("/class/classes", headers={"Content-Type": "application/json"})
+    assert response.status_code == 200
+
+    course_payload = next(c for c in response.json if c["id"] == seeded["course"].id)
+    assert course_payload["total_grade"] is None

--- a/frontend/src/components/ClassCard.css
+++ b/frontend/src/components/ClassCard.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: relative;
 
   width: 360px;
   height: 240px;

--- a/frontend/src/components/ClassCard.tsx
+++ b/frontend/src/components/ClassCard.tsx
@@ -1,15 +1,21 @@
 import './ClassCard.css'
+import CourseGradeBadge from './CourseGradeBadge'
 
 interface Props {
   image: string
   name: string
   subtitle: string
+  gradeLabel?: string
+  gradeUnavailable?: boolean
   onclick?: () => void
 }
 
 export default function ClassCard(props: Props) {
   return (
     <div className="ClassCard" onClick={props.onclick}>
+      {props.gradeLabel ? (
+        <CourseGradeBadge label={props.gradeLabel} unavailable={props.gradeUnavailable} />
+      ) : null}
       <img src={props.image} alt={props.name} />
       <div className="ClassInfo">
         <h2>{props.name}</h2>

--- a/frontend/src/components/CourseGradeBadge.css
+++ b/frontend/src/components/CourseGradeBadge.css
@@ -1,0 +1,34 @@
+.CourseGradeBadge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 2;
+
+  min-width: 110px;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  background: rgba(10, 83, 10, 0.92);
+  color: #ffffff;
+
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  line-height: 1.1;
+}
+
+.CourseGradeBadgeCaption {
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.CourseGradeBadge strong {
+  margin-top: 0.1rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.CourseGradeBadge.Unavailable {
+  background: rgba(85, 92, 102, 0.94);
+}

--- a/frontend/src/components/CourseGradeBadge.tsx
+++ b/frontend/src/components/CourseGradeBadge.tsx
@@ -1,0 +1,15 @@
+import "./CourseGradeBadge.css";
+
+interface CourseGradeBadgeProps {
+  label: string;
+  unavailable?: boolean;
+}
+
+export default function CourseGradeBadge({ label, unavailable = false }: CourseGradeBadgeProps) {
+  return (
+    <div className={`CourseGradeBadge ${unavailable ? "Unavailable" : ""}`}>
+      <span className="CourseGradeBadgeCaption">Total Grade</span>
+      <strong>{label}</strong>
+    </div>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import { isTeacher, isStudent } from "../util/login";
 export default function Home() {
   const [courses, setCourses] = useState<CourseWithAssignments[]>([]);
   const [loading, setLoading] = useState(true);
+  const studentView = isStudent();
 
   useEffect(() => {
     ;(async () => {
@@ -79,6 +80,11 @@ export default function Home() {
         {courses.length > 0 ? (
           courses.map((course) => {
             const assignmentText = `${course.assignmentCount || 0} assignments`;
+            const hasTotalGrade =
+              typeof course.total_grade === "number" && Number.isFinite(course.total_grade);
+            const formattedGrade = hasTotalGrade
+              ? `${course.total_grade!.toFixed(1).replace(/\.0$/, "")}%`
+              : "Grade unavailable";
 
             return (
               <ClassCard
@@ -86,6 +92,8 @@ export default function Home() {
                 image="https://crc.losrios.edu//shared/img/social-1200-630/programs/general-science-social.jpg"
                 name={course.name}
                 subtitle={assignmentText}
+                gradeLabel={studentView ? formattedGrade : undefined}
+                gradeUnavailable={studentView && !hasTotalGrade}
                 onclick={() => {
                   window.location.href = `/classes/${course.id}/home`
                 }}

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -2,6 +2,7 @@ interface Course {
   id: number;
   teacherID: number;
   name: string;
+  total_grade?: number | null;
 }
 
 interface User {


### PR DESCRIPTION
Add backend grade calculation and surface it in the UI. Introduces calculate_student_course_total_grade service (and services package) that computes a student's course percentage (rounded to 1 decimal) or returns None when unavailable, and wires it into the class listing endpoint to include total_grade for student users. Adds tests covering available and unavailable grade scenarios. Frontend: add CourseGradeBadge component and styles, update ClassCard to optionally render the badge, update Home to format and pass total_grade for student view, and extend Course type with total_grade. Also minor CSS adjustment to ClassCard positioning.