### PR TITLE
Add cascade delete and deletion UI for users

### DIFF
--- a/flask_backend/api/controllers/admin_controller.py
+++ b/flask_backend/api/controllers/admin_controller.py
@@ -129,7 +129,9 @@ def update_user_role(user_id):
 @bp.route("/users/<int:user_id>", methods=["DELETE"])
 @jwt_admin_required
 def delete_user(user_id):
-    """Delete a user (admin only)"""
+    """Delete a user (admin only). Supports cascade deletion via ?cascade=true query parameter"""
+    from flask import request
+    
     current_email = get_jwt_identity()
     current_user = User.get_by_email(current_email)
 
@@ -141,30 +143,49 @@ def delete_user(user_id):
     if not user:
         return jsonify({"msg": "User not found"}), 404
 
-    blockers = user.get_delete_blockers()
-    blocking_references = {key: value for key, value in blockers.items() if value > 0}
-    if blocking_references:
-        return (
-            jsonify(
-                {
-                    "msg": "Cannot delete user because they are still referenced by existing records",
-                    "blockers": blocking_references,
-                }
-            ),
-            409,
-        )
+    # Check if cascade deletion was requested
+    cascade = request.args.get("cascade", "false").lower() == "true"
+    
+    if cascade:
+        # Perform cascade deletion
+        try:
+            user.cascade_delete()
+            return jsonify({"msg": "User and all associated records deleted successfully"}), 200
+        except Exception as e:
+            return (
+                jsonify({"msg": f"Error deleting user: {str(e)}"}),
+                500,
+            )
+    else:
+        # Normal delete with blocker check
+        blockers = user.get_delete_blockers()
+        blocking_references = {key: value for key, value in blockers.items() if value > 0}
+        if blocking_references:
+            associations = user.get_delete_associations()
+            return (
+                jsonify(
+                    {
+                        "msg": "Cannot delete user because they are still referenced by existing records",
+                        "blockers": blocking_references,
+                        "associations": associations,
+                    }
+                ),
+                409,
+            )
 
-    try:
-        user.delete()
-    except IntegrityError:
-        return (
-            jsonify(
-                {
-                    "msg": "Cannot delete user because they are still referenced by existing records",
-                    "blockers": user.get_delete_blockers(),
-                }
-            ),
-            409,
-        )
+        try:
+            user.delete()
+        except IntegrityError:
+            associations = user.get_delete_associations()
+            return (
+                jsonify(
+                    {
+                        "msg": "Cannot delete user because they are still referenced by existing records",
+                        "blockers": user.get_delete_blockers(),
+                        "associations": associations,
+                    }
+                ),
+                409,
+            )
 
-    return jsonify({"msg": "User deleted successfully"}), 200
+        return jsonify({"msg": "User deleted successfully"}), 200

--- a/flask_backend/api/models/user_model.py
+++ b/flask_backend/api/models/user_model.py
@@ -123,6 +123,103 @@ class User(db.Model):
             "group_memberships": self.group_memberships.count(),
         }
 
+    def get_delete_associations(self):
+        """Return detailed information about all associations that reference this user."""
+        associations = {}
+        
+        # Teaching courses
+        teaching = self.teaching_courses.all()
+        if teaching:
+            associations["teaching_courses"] = {
+                "count": len(teaching),
+                "items": [{"id": c.id, "name": c.name} for c in teaching]
+            }
+        
+        # Enrollments (student in courses)
+        enrollments = self.user_courses.all()
+        if enrollments:
+            associations["enrollments"] = {
+                "count": len(enrollments),
+                "items": [{"course_id": uc.courseID, "course_name": uc.course.name} 
+                         for uc in enrollments if uc.course]
+            }
+        
+        # Submissions
+        submissions = self.submissions.all()
+        if submissions:
+            associations["submissions"] = {
+                "count": len(submissions),
+                "items": [{"id": s.id, "assignment_id": s.assignmentID, 
+                          "assignment_name": s.assignment.name if s.assignment else "Unknown"}
+                         for s in submissions]
+            }
+        
+        # Reviews made
+        reviews_made = self.reviews_made.all()
+        if reviews_made:
+            associations["reviews_made"] = {
+                "count": len(reviews_made),
+                "items": [{"id": r.id, "assignment_id": r.assignmentID,
+                          "reviewee_id": r.revieweeID, "reviewee_name": r.reviewee.name if r.reviewee else "Unknown"}
+                         for r in reviews_made]
+            }
+        
+        # Reviews received
+        reviews_received = self.reviews_received.all()
+        if reviews_received:
+            associations["reviews_received"] = {
+                "count": len(reviews_received),
+                "items": [{"id": r.id, "assignment_id": r.assignmentID,
+                          "reviewer_id": r.reviewerID, "reviewer_name": r.reviewer.name if r.reviewer else "Unknown"}
+                         for r in reviews_received]
+            }
+        
+        # Group memberships
+        group_memberships = self.group_memberships.all()
+        if group_memberships:
+            associations["group_memberships"] = {
+                "count": len(group_memberships),
+                "items": [{"group_id": gm.groupID, 
+                          "group_name": gm.group.name if gm.group else "Unknown"}
+                         for gm in group_memberships]
+            }
+        
+        return associations
+
+    def cascade_delete(self):
+        """Delete all associations and then delete the user."""
+        try:
+            # Delete teaching courses (cascade should handle this via relationship)
+            for course in self.teaching_courses.all():
+                db.session.delete(course)
+            
+            # Delete enrollments (user_courses)
+            for enrollment in self.user_courses.all():
+                db.session.delete(enrollment)
+            
+            # Delete submissions (cascade should handle via relationship)
+            for submission in self.submissions.all():
+                db.session.delete(submission)
+            
+            # Delete reviews made by this user
+            for review in self.reviews_made.all():
+                db.session.delete(review)
+            
+            # Delete reviews received by this user
+            for review in self.reviews_received.all():
+                db.session.delete(review)
+            
+            # Delete group memberships (cascade should handle via relationship)
+            for membership in self.group_memberships.all():
+                db.session.delete(membership)
+            
+            # Finally delete the user
+            db.session.delete(self)
+            db.session.commit()
+        except Exception as e:
+            db.session.rollback()
+            raise e
+
     def is_teacher_user(self):
         """Check if the user is a teacher (backward compatibility)"""
         return self.role == "teacher"

--- a/frontend/src/components/DeleteUserModal.css
+++ b/frontend/src/components/DeleteUserModal.css
@@ -1,0 +1,203 @@
+.DeleteUserModalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+}
+
+.DeleteUserModal {
+  width: min(92vw, 600px);
+  max-height: 85vh;
+  background: #fff;
+  border-radius: 10px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+}
+
+.DeleteUserModalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.DeleteUserModalHeader h2 {
+  margin: 0;
+  color: #111827;
+  font-size: 1.1rem;
+}
+
+.DeleteUserModalClose {
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  font-size: 1.5rem;
+  line-height: 1;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.DeleteUserModalClose:hover:not(:disabled) {
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.DeleteUserModalClose:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.DeleteUserModalContent {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.2rem;
+}
+
+.DeleteUserModalText {
+  margin: 0 0 1rem 0;
+  color: #374151;
+  font-size: 0.95rem;
+}
+
+.DeleteUserAssociationsList {
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 1rem 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.AssociationCategory {
+  margin-bottom: 1rem;
+}
+
+.AssociationCategory:last-child {
+  margin-bottom: 0;
+}
+
+.AssociationTitle {
+  margin: 0 0 0.5rem 0;
+  color: #6b7280;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.AssociationItems {
+  margin: 0;
+  padding-left: 1.5rem;
+  list-style-type: disc;
+  color: #4b5563;
+  font-size: 0.9rem;
+}
+
+.AssociationItems li {
+  margin: 0.25rem 0;
+  word-break: break-word;
+}
+
+.MoreItems {
+  font-style: italic;
+  color: #9ca3af;
+}
+
+.DeleteUserWarningBox {
+  padding: 1rem;
+  margin: 1rem 0;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+}
+
+.DeleteUserCheckbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  cursor: pointer;
+}
+
+.DeleteUserCheckbox input {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.DeleteUserCheckbox input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.DeleteUserCheckbox span {
+  color: #991b1b;
+  font-weight: 500;
+}
+
+.DeleteUserError {
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.DeleteUserModalActions {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1.2rem;
+  border-top: 1px solid #e5e7eb;
+  background: #fafafa;
+}
+
+.DeleteUserCancelButton,
+.DeleteUserConfirmButton {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.DeleteUserCancelButton {
+  background: #fff;
+  color: #374151;
+}
+
+.DeleteUserCancelButton:hover:not(:disabled) {
+  background: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.DeleteUserConfirmButton {
+  background: #ef4444;
+  color: #fff;
+  border-color: #dc2626;
+}
+
+.DeleteUserConfirmButton:hover:not(:disabled) {
+  background: #f87171;
+  border-color: #ef4444;
+}
+
+.DeleteUserCancelButton:disabled,
+.DeleteUserConfirmButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/DeleteUserModal.tsx
+++ b/frontend/src/components/DeleteUserModal.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import "./DeleteUserModal.css";
+
+interface Association {
+  count: number;
+  items: Array<Record<string, unknown>>;
+}
+
+interface DeleteUserModalProps {
+  isOpen: boolean;
+  userName: string;
+  associations: Record<string, Association>;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}
+
+export default function DeleteUserModal({
+  isOpen,
+  userName,
+  associations,
+  onClose,
+  onConfirm,
+}: DeleteUserModalProps) {
+  const [deleteInProgress, setDeleteInProgress] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleClose = () => {
+    if (deleteInProgress) {
+      return;
+    }
+    setConfirmed(false);
+    setDeleteError(null);
+    onClose();
+  };
+
+  const handleDelete = async () => {
+    setDeleteInProgress(true);
+    setDeleteError(null);
+    try {
+      await onConfirm();
+      handleClose();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to delete user";
+      setDeleteError(message);
+    } finally {
+      setDeleteInProgress(false);
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const totalAssociations = Object.values(associations).reduce((sum, assoc) => sum + assoc.count, 0);
+  const associationLabel = totalAssociations === 1 ? "item" : "items";
+
+  return (
+    <div className="DeleteUserModalOverlay" onClick={handleClose}>
+      <div className="DeleteUserModal" onClick={(event) => event.stopPropagation()}>
+        <div className="DeleteUserModalHeader">
+          <h2>Delete User?</h2>
+          <button
+            className="DeleteUserModalClose"
+            onClick={handleClose}
+            aria-label="Close delete dialog"
+            disabled={deleteInProgress}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="DeleteUserModalContent">
+          <p className="DeleteUserModalText">
+            This will permanently delete <strong>{userName}</strong> and all associated records ({totalAssociations} {associationLabel}):
+          </p>
+
+          <div className="DeleteUserAssociationsList">
+            {Object.entries(associations).map(([key, assoc]) => (
+              <div key={key} className="AssociationCategory">
+                <h3 className="AssociationTitle">
+                  {formatAssociationKey(key)} ({assoc.count})
+                </h3>
+                <ul className="AssociationItems">
+                  {assoc.items.slice(0, 5).map((item, idx) => (
+                    <li key={idx}>{formatAssociationItem(item)}</li>
+                  ))}
+                  {assoc.items.length > 5 && (
+                    <li className="MoreItems">... and {assoc.items.length - 5} more</li>
+                  )}
+                </ul>
+              </div>
+            ))}
+          </div>
+
+          {deleteError ? <p className="DeleteUserError">{deleteError}</p> : null}
+
+          <div className="DeleteUserWarningBox">
+            <label className="DeleteUserCheckbox">
+              <input
+                type="checkbox"
+                checked={confirmed}
+                onChange={(event) => setConfirmed(event.target.checked)}
+                disabled={deleteInProgress}
+              />
+              <span>I understand this action cannot be undone</span>
+            </label>
+          </div>
+        </div>
+
+        <div className="DeleteUserModalActions">
+          <button
+            className="DeleteUserCancelButton"
+            onClick={handleClose}
+            disabled={deleteInProgress}
+          >
+            Cancel
+          </button>
+          <button
+            className="DeleteUserConfirmButton"
+            onClick={handleDelete}
+            disabled={deleteInProgress || !confirmed}
+          >
+            Delete User and All Records
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatAssociationKey(key: string): string {
+  return key
+    .replace(/_/g, " ")
+    .split(" ")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function formatAssociationItem(item: Record<string, unknown>): string {
+  if (item.name) return `${item.name}`;
+  if (item.course_name) return `Course: ${item.course_name}`;
+  if (item.assignment_name) return `Assignment: ${item.assignment_name}`;
+  if (item.reviewee_name) return `Review of: ${item.reviewee_name}`;
+  if (item.reviewer_name) return `Review from: ${item.reviewer_name}`;
+  if (item.group_name) return `Group: ${item.group_name}`;
+  return JSON.stringify(item);
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useState } from "react";
-import { listUsers, deleteUser } from "../util/api";
+import { listUsers, deleteUser, deleteUserCascade, DeleteUserConflictError } from "../util/api";
+import DeleteUserModal from "../components/DeleteUserModal";
 import "./AdminPage.css";
 export default function AdminPage() {
+  type UserAssociations = Record<string, { count: number; items: Array<Record<string, unknown>> }>;
+
   const [users, setUsers] = useState<User[]>([]);
   const [statusMessage, setStatusMessage] = useState<string>("");
   const [statusType, setStatusType] = useState<"error" | "success">("error");
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteModalUser, setDeleteModalUser] = useState<User | null>(null);
+  const [deleteModalAssociations, setDeleteModalAssociations] = useState<UserAssociations>({});
   const currentUser = JSON.parse(localStorage.getItem("user") || "null");
 
   async function handleDelete(userId: number) {
@@ -22,6 +28,34 @@ export default function AdminPage() {
       setUsers((prev) => prev.filter((u) => u.id !== userId));
       setStatusType("success");
       setStatusMessage("User deleted successfully.");
+    } catch (err) {
+      if (err instanceof DeleteUserConflictError) {
+        // Show the modal with associations
+        const userToDelete = users.find((u) => u.id === userId);
+        if (userToDelete) {
+          setDeleteModalUser(userToDelete);
+          setDeleteModalAssociations(err.associations);
+          setShowDeleteModal(true);
+        }
+      } else {
+        const message = err instanceof Error ? err.message : "Failed to delete user.";
+        setStatusType("error");
+        setStatusMessage(message);
+        console.error("Failed to delete user:", err);
+      }
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!deleteModalUser) return;
+
+    try {
+      await deleteUserCascade(deleteModalUser.id);
+      setUsers((prev) => prev.filter((u) => u.id !== deleteModalUser.id));
+      setShowDeleteModal(false);
+      setDeleteModalUser(null);
+      setStatusType("success");
+      setStatusMessage(`User ${deleteModalUser.name} has been deleted successfully.`);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to delete user.";
       setStatusType("error");
@@ -86,6 +120,17 @@ export default function AdminPage() {
         </tbody>
       </table>
     </div>
+
+    <DeleteUserModal
+      isOpen={showDeleteModal}
+      userName={deleteModalUser?.name || ""}
+      associations={deleteModalAssociations}
+      onClose={() => {
+        setShowDeleteModal(false);
+        setDeleteModalUser(null);
+      }}
+      onConfirm={handleConfirmDelete}
+    />
   </div>
 )
 }

--- a/frontend/src/pages/Assignment.tsx
+++ b/frontend/src/pages/Assignment.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import Button from "../components/Button";
@@ -17,6 +18,14 @@ export default function Assignment() {
   const searchClassId = new URLSearchParams(location.search).get("classId");
   const classId = stateClassId ?? searchClassId;
   const classQuery = classId ? `?classId=${classId}` : "";
+
+  useEffect(() => {
+    if (!canManageAssignment || !id) {
+      return;
+    }
+
+    navigate(`/assignment/${id}/criteria${classQuery}`, { replace: true });
+  }, [canManageAssignment, id, classQuery, navigate]);
 
   return (
     <div className="AssignmentPage container-fluid py-4 px-3 px-md-4">
@@ -57,28 +66,9 @@ export default function Assignment() {
         ]}
       />
 
-      {canManageAssignment ? (
-        <div className="card border-0 shadow-sm p-3 p-md-4 mt-3 AssignmentHomePanel">
-          <h3 className="h5 fw-semibold mb-2">Assignment Overview</h3>
-          <p className="text-muted mb-3">
-            Use this page as the instructor landing area for assignment setup and monitoring.
-          </p>
-
-          <div className="AssignmentHomeActions">
-            <button type="button" onClick={() => (window.location.href = `/assignment/${id}/criteria`)}>
-              Edit Criteria
-            </button>
-            <button type="button" onClick={() => (window.location.href = `/assignments/${id}/reviews`)}>
-              Manage Reviews
-            </button>
-            <button type="button" onClick={() => (window.location.href = `/assignments/${id}/progress`)}>
-              View Progress
-            </button>
-          </div>
-        </div>
-      ) : (
+      {!canManageAssignment ? (
         <StudentAssignedReviews assignmentId={assignmentId} />
-      )}
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/util/api.ts
+++ b/frontend/src/util/api.ts
@@ -1314,6 +1314,18 @@ export const updateUserRole = async (id: number, role: string) => {
   return await response.json();
 };
 
+export class DeleteUserConflictError extends Error {
+  associations: Record<string, { count: number; items: Array<Record<string, unknown>> }>;
+  blockers: Record<string, number>;
+
+  constructor(msg: string, associations: unknown, blockers: unknown) {
+    super(msg);
+    this.name = 'DeleteUserConflictError';
+    this.associations = associations as typeof this.associations;
+    this.blockers = blockers as typeof this.blockers;
+  }
+}
+
 export const deleteUser = async (userId: number) => {
   const response = await fetch(`${BASE_URL}/admin/users/${userId}`, {
     method: 'DELETE',
@@ -1325,12 +1337,33 @@ export const deleteUser = async (userId: number) => {
   if (!response.ok) {
     const errorData = await response.json().catch(() => null);
     if (errorData?.msg && errorData?.blockers && typeof errorData.blockers === 'object') {
+      // If there are associations, throw a special error
+      if (errorData?.associations && typeof errorData.associations === 'object') {
+        const error = new DeleteUserConflictError(errorData.msg, errorData.associations, errorData.blockers);
+        throw error;
+      }
       const blockerSummary = Object.entries(errorData.blockers)
         .filter(([, count]) => Number(count) > 0)
         .map(([key, count]) => `${key}: ${count}`)
         .join(', ');
       throw new Error(blockerSummary ? `${errorData.msg}. ${blockerSummary}` : errorData.msg);
     }
+    throw new Error(errorData?.msg || `Response status: ${response.status}`);
+  }
+
+  return await response.json();
+};
+
+export const deleteUserCascade = async (userId: number) => {
+  const response = await fetch(`${BASE_URL}/admin/users/${userId}?cascade=true`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+
+  maybeHandleExpire(response);
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => null);
     throw new Error(errorData?.msg || `Response status: ${response.status}`);
   }
 


### PR DESCRIPTION
Implement cascade deletion and improved UX for admin user removal. Backend: admin_controller DELETE /users now supports ?cascade=true and returns detailed associations when deletion is blocked; user_model gains get_delete_associations() and cascade_delete() to collect and remove related records. Frontend: new DeleteUserModal (TSX + CSS) to show associated records and confirmation UI; AdminPage updated to open the modal on delete conflicts and call deleteUserCascade when confirmed. API util: introduced DeleteUserConflictError, enhanced deleteUser to throw it when associations are returned, and added deleteUserCascade helper. Also minor tweaks in Assignment page to auto-navigate managers to criteria and adjust the instructor panel rendering.