### PR TITLE
Add rate limiting, upload size limits, and ACLs

### DIFF
--- a/flask_backend/api/__init__.py
+++ b/flask_backend/api/__init__.py
@@ -77,6 +77,20 @@ def create_app(test_config=None):
         ),  # Strict in production for maximum security
         JWT_ACCESS_COOKIE_PATH="/",
         JWT_COOKIE_DOMAIN=os.environ.get("JWT_COOKIE_DOMAIN", None),
+        MAX_SUBMISSION_FILE_SIZE_BYTES=int(
+            os.environ.get("MAX_SUBMISSION_FILE_SIZE_BYTES", str(10 * 1024 * 1024))
+        ),
+        MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES=int(
+            os.environ.get("MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES", str(10 * 1024 * 1024))
+        ),
+        RATE_LIMIT_TRUST_PROXY_HEADERS=(
+            os.environ.get("RATE_LIMIT_TRUST_PROXY_HEADERS", "false").lower() == "true"
+        ),
+        LOGIN_ATTEMPT_WINDOW_SECONDS=int(os.environ.get("LOGIN_ATTEMPT_WINDOW_SECONDS", "300")),
+        LOGIN_ATTEMPT_MAX_FAILURES=int(os.environ.get("LOGIN_ATTEMPT_MAX_FAILURES", "10")),
+        LOGIN_LOCKOUT_SECONDS=int(os.environ.get("LOGIN_LOCKOUT_SECONDS", "120")),
+        REGISTER_ATTEMPT_WINDOW_SECONDS=int(os.environ.get("REGISTER_ATTEMPT_WINDOW_SECONDS", "300")),
+        REGISTER_ATTEMPT_MAX_ATTEMPTS=int(os.environ.get("REGISTER_ATTEMPT_MAX_ATTEMPTS", "10")),
     )
 
     if test_config is None:

--- a/flask_backend/api/controllers/assignment_attachment_controller.py
+++ b/flask_backend/api/controllers/assignment_attachment_controller.py
@@ -1,13 +1,14 @@
 import io
 import uuid
 
-from flask import Blueprint, jsonify, request, send_file
+from flask import Blueprint, current_app, jsonify, request, send_file
 from flask_jwt_extended import get_jwt_identity, jwt_required
 
 from ..models import Assignment, AssignmentAttachment, Course, User, User_Course
 from .auth_controller import jwt_teacher_required
 
 bp = Blueprint("assignment_attachment", __name__, url_prefix="/assignment")
+DEFAULT_MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024
 
 
 def _can_access_course(user, course):
@@ -35,6 +36,21 @@ def _serialize_attachment_metadata(assignment_id, attachment):
         "original_name": attachment.original_name,
         "download_url": f"/assignment/{assignment_id}/attachment/{attachment.stored_name}",
     }
+
+
+def _read_attachment_with_limit(uploaded_file):
+    max_file_size = int(
+        current_app.config.get(
+            "MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES",
+            DEFAULT_MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES,
+        )
+    )
+    content = uploaded_file.read(max_file_size + 1)
+    if len(content) > max_file_size:
+        raise ValueError(
+            f"Attachment exceeds maximum size ({max_file_size} bytes)"
+        )
+    return content
 
 
 def _get_assignment_for_teacher_edit(assignment_id):
@@ -92,7 +108,7 @@ def save_assignment_attachments(assignment_id):
         if not original_name:
             continue
 
-        content = uploaded_file.read()
+        content = _read_attachment_with_limit(uploaded_file)
         stored_name = uuid.uuid4().hex
         attachment = AssignmentAttachment(
             assignmentID=assignment_id,
@@ -128,7 +144,11 @@ def add_assignment_attachments(assignment_id):
     if error:
         return error
 
-    saved_files = save_assignment_attachments(assignment.id)
+    try:
+        saved_files = save_assignment_attachments(assignment.id)
+    except ValueError as exc:
+        return jsonify({"msg": str(exc)}), 413
+
     if not saved_files:
         return jsonify({"msg": "No attachments uploaded"}), 400
 

--- a/flask_backend/api/controllers/assignment_controller.py
+++ b/flask_backend/api/controllers/assignment_controller.py
@@ -8,6 +8,7 @@ from ..models import (
     AssignmentSchema,
     Course,
     User,
+    User_Course,
 )
 from ..services import build_assignment_progress_payload, clear_assignment_groups
 from .auth_controller import jwt_teacher_required
@@ -19,6 +20,14 @@ from .helpers import get_teacher_managed_assignment
 
 bp = Blueprint("assignment", __name__, url_prefix="/assignment")
 VALID_ASSIGNMENT_MODES = {"solo", "group"}
+
+
+def _can_access_course(user, course):
+    if user.is_admin():
+        return True
+    if course.teacherID == user.id:
+        return True
+    return User_Course.get(user.id, course.id) is not None
 
 
 def _parse_request_data():
@@ -113,7 +122,10 @@ def create_assignment():
         description=description,
     )
     Assignment.create(new_assignment)
-    saved_files = save_assignment_attachments(new_assignment.id)
+    try:
+        saved_files = save_assignment_attachments(new_assignment.id)
+    except ValueError as exc:
+        return jsonify({"msg": str(exc)}), 413
 
     return (
         jsonify(
@@ -226,6 +238,13 @@ def get_assignments(class_id):
     course = Course.get_by_id(class_id)
     if not course:
         return jsonify({"msg": "Class not found"}), 404
+
+    email = get_jwt_identity()
+    current_user = User.get_by_email(email)
+    if not current_user:
+        return jsonify({"msg": "User not found"}), 404
+    if not _can_access_course(current_user, course):
+        return jsonify({"msg": "Insufficient permissions"}), 403
 
     assignments = Assignment.get_by_class_id(class_id)
     assignments_data = AssignmentSchema(many=True).dump(assignments)

--- a/flask_backend/api/controllers/auth_controller.py
+++ b/flask_backend/api/controllers/auth_controller.py
@@ -1,6 +1,8 @@
 import functools
+import threading
+import time
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import (
     create_access_token,
     get_jwt_identity,
@@ -15,15 +17,124 @@ from ..models import User, UserLoginSchema, UserRegistrationSchema, UserSchema
 
 bp = Blueprint("auth", __name__, url_prefix="/auth")
 
+LOGIN_ATTEMPT_WINDOW_SECONDS = 5 * 60
+LOGIN_ATTEMPT_MAX_FAILURES = 5
+LOGIN_LOCKOUT_SECONDS = 10 * 60
+REGISTER_ATTEMPT_WINDOW_SECONDS = 5 * 60
+REGISTER_ATTEMPT_MAX_ATTEMPTS = 10
+
+_failed_login_attempts = {}
+_lockout_until = {}
+_register_attempts = {}
+_login_attempt_lock = threading.Lock()
+
 # Create schema instances once (reusable)
 registration_schema = UserRegistrationSchema()
 login_schema = UserLoginSchema()
 user_schema = UserSchema()
 
 
+def _get_config_int(name, default_value):
+    value = current_app.config.get(name, default_value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default_value)
+
+
+def _get_rate_limit_client_ip():
+    client_ip = request.remote_addr or "unknown"
+    if not current_app.config.get("RATE_LIMIT_TRUST_PROXY_HEADERS", False):
+        return client_ip
+
+    # Only trusted deployments should enable this; otherwise a client can spoof it.
+    forwarded_for = (request.headers.get("X-Forwarded-For") or "").split(",")[0].strip()
+    return forwarded_for or client_ip
+
+
+def _get_login_throttle_key(email):
+    client_ip = _get_rate_limit_client_ip()
+    normalized_email = (email or "").strip().lower()
+    return f"{client_ip}:{normalized_email}"
+
+
+def _get_register_throttle_key():
+    return _get_rate_limit_client_ip()
+
+
+def _prune_attempts(attempts, now, window_seconds):
+    return [ts for ts in attempts if now - ts <= window_seconds]
+
+
+def _get_lockout_remaining_seconds(key, now):
+    locked_until = _lockout_until.get(key)
+    if not locked_until:
+        return 0
+
+    remaining = int(locked_until - now)
+    if remaining > 0:
+        return remaining
+
+    _lockout_until.pop(key, None)
+    return 0
+
+
+def _record_failed_login_attempt(key, now):
+    window_seconds = _get_config_int("LOGIN_ATTEMPT_WINDOW_SECONDS", LOGIN_ATTEMPT_WINDOW_SECONDS)
+    max_failures = _get_config_int("LOGIN_ATTEMPT_MAX_FAILURES", LOGIN_ATTEMPT_MAX_FAILURES)
+    lockout_seconds = _get_config_int("LOGIN_LOCKOUT_SECONDS", LOGIN_LOCKOUT_SECONDS)
+
+    attempts = _prune_attempts(_failed_login_attempts.get(key, []), now, window_seconds)
+    attempts.append(now)
+    _failed_login_attempts[key] = attempts
+
+    if len(attempts) >= max_failures:
+        _lockout_until[key] = now + lockout_seconds
+        _failed_login_attempts.pop(key, None)
+        return int(lockout_seconds)
+
+    return 0
+
+
+def _clear_login_failures(key):
+    _failed_login_attempts.pop(key, None)
+    _lockout_until.pop(key, None)
+
+
+def _register_rate_limit_retry_after_seconds(key, now):
+    window_seconds = _get_config_int("REGISTER_ATTEMPT_WINDOW_SECONDS", REGISTER_ATTEMPT_WINDOW_SECONDS)
+    max_attempts = _get_config_int("REGISTER_ATTEMPT_MAX_ATTEMPTS", REGISTER_ATTEMPT_MAX_ATTEMPTS)
+
+    attempts = _prune_attempts(_register_attempts.get(key, []), now, window_seconds)
+    if len(attempts) >= max_attempts:
+        _register_attempts[key] = attempts
+        oldest_attempt = attempts[0]
+        return max(1, int(window_seconds - (now - oldest_attempt)))
+
+    attempts.append(now)
+    _register_attempts[key] = attempts
+    return 0
+
+
 @bp.route("/register", methods=["POST"])
 def register():
     """Register a new user account (student only - teachers/admins created by admins)"""
+    now = time.time()
+    throttle_key = _get_register_throttle_key()
+    with _login_attempt_lock:
+        retry_after = _register_rate_limit_retry_after_seconds(throttle_key, now)
+    if retry_after > 0:
+        return (
+            jsonify(
+                {
+                    "msg": f"Too many registration attempts. Try again in {retry_after} seconds.",
+                    "retry_after_seconds": retry_after,
+                    "locked_until_unix": int(now + retry_after),
+                }
+            ),
+            429,
+        )
+
     if not request.is_json:
         return jsonify({"msg": "Missing JSON in request"}), 400
 
@@ -62,10 +173,43 @@ def login():
     except ValidationError as err:
         return jsonify({"msg": "Validation error", "errors": err.messages}), 400
 
+    throttle_key = _get_login_throttle_key(data.get("email"))
+    now = time.time()
+    with _login_attempt_lock:
+        retry_after = _get_lockout_remaining_seconds(throttle_key, now)
+    if retry_after > 0:
+        return (
+            jsonify(
+                {
+                    "msg": f"Too many failed login attempts. Try again in {retry_after} seconds.",
+                    "retry_after_seconds": retry_after,
+                    "locked_until_unix": int(now + retry_after),
+                }
+            ),
+            429,
+        )
+
     # Verify credentials
     user = User.get_by_email(data["email"])
     if user is None or not check_password_hash(user.hash_pass, data["password"]):
+        now = time.time()
+        with _login_attempt_lock:
+            lockout_seconds = _record_failed_login_attempt(throttle_key, now)
+        if lockout_seconds > 0:
+            return (
+                jsonify(
+                    {
+                        "msg": f"Too many failed login attempts. Try again in {lockout_seconds} seconds.",
+                        "retry_after_seconds": lockout_seconds,
+                        "locked_until_unix": int(now + lockout_seconds),
+                    }
+                ),
+                429,
+            )
         return jsonify({"msg": "Bad email or password"}), 401
+
+    with _login_attempt_lock:
+        _clear_login_failures(throttle_key)
 
     # Generate access token and set as httponly cookie
     access_token = create_access_token(identity=data["email"])

--- a/flask_backend/api/controllers/rubric_controller.py
+++ b/flask_backend/api/controllers/rubric_controller.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, jsonify, request # type: ignore
-from flask_jwt_extended import get_jwt_identity
+from flask_jwt_extended import get_jwt_identity, jwt_required
 
 from ..models import (
     Assignment,
@@ -8,6 +8,7 @@ from ..models import (
     CriteriaDescriptionSchema,
     Rubric,
     RubricSchema,
+    User_Course,
     User,
 )
 from .auth_controller import jwt_teacher_required
@@ -59,6 +60,22 @@ def _can_manage_assignment(assignment):
     return user.is_admin() or course.teacherID == user.id
 
 
+def _can_view_assignment(assignment):
+    user = User.get_by_email(get_jwt_identity())
+    if not user:
+        return False
+
+    course = Course.get_by_id(assignment.courseID)
+    if not course:
+        return False
+
+    return (
+        user.is_admin()
+        or course.teacherID == user.id
+        or User_Course.get(user.id, course.id) is not None
+    )
+
+
 def _validate_assignment_scope_for_rubric(assignment_id, rubric):
     if rubric.assignmentID != int(assignment_id):
         return jsonify({"msg": "Rubric does not belong to the specified assignment"}), 400
@@ -73,8 +90,15 @@ def _validate_assignment_scope_for_criteria(assignment_id, criteria):
 
 
 @bp.route("/rubric/assignment/<int:assignment_id>", methods=["GET"])
+@jwt_required()
 def get_rubric_by_assignment(assignment_id):
     """Get the rubric for a given assignment ID"""
+    assignment = Assignment.get_by_id(assignment_id)
+    if not assignment:
+        return jsonify({"msg": "Assignment not found"}), 404
+    if not _can_view_assignment(assignment):
+        return jsonify({"msg": "Insufficient permissions"}), 403
+
     rubric_type = request.args.get("rubricType") or request.args.get("rubric_type")
     normalized_rubric_type = Rubric.normalize_rubric_type(rubric_type)
     if rubric_type is not None and normalized_rubric_type is None:
@@ -92,8 +116,15 @@ def get_rubric_by_assignment(assignment_id):
 
 
 @bp.route("/rubric/assignment/<int:assignment_id>/separated", methods=["GET"])
+@jwt_required()
 def get_rubrics_by_assignment_separated(assignment_id):
     """Get peer and group rubrics separately for an assignment."""
+    assignment = Assignment.get_by_id(assignment_id)
+    if not assignment:
+        return jsonify({"msg": "Assignment not found"}), 404
+    if not _can_view_assignment(assignment):
+        return jsonify({"msg": "Insufficient permissions"}), 403
+
     peer_rubric = Rubric.get_for_assignment(assignment_id, "peer")
     group_rubric = Rubric.get_for_assignment(assignment_id, "group")
 
@@ -113,6 +144,7 @@ def get_rubrics_by_assignment_separated(assignment_id):
 
 
 @bp.route("/criteria", methods=["GET"])
+@jwt_required()
 def get_criteria():
     """Get all criteria descriptions for a rubric"""
     rubric_id = request.args.get("rubricID")
@@ -127,6 +159,12 @@ def get_criteria():
     rubric = Rubric.get_by_id(rubric_id)
     if not rubric:
         return jsonify({"msg": "Rubric not found"}), 404
+
+    assignment = Assignment.get_by_id(rubric.assignmentID)
+    if not assignment:
+        return jsonify({"msg": "Assignment not found"}), 404
+    if not _can_view_assignment(assignment):
+        return jsonify({"msg": "Insufficient permissions"}), 403
 
     criteria = rubric.criteria_descriptions.all()
     return jsonify(CriteriaDescriptionSchema(many=True).dump(criteria)), 200
@@ -374,6 +412,7 @@ def delete_criteria_for_assignment(assignment_id, criteria_id):
 
 
 @bp.route("/rubric", methods=["GET"])
+@jwt_required()
 def get_rubric():
     """Get a rubric and its criteria descriptions by rubric ID"""
     rubric_id = request.args.get("rubricID")
@@ -388,6 +427,12 @@ def get_rubric():
     rubric = Rubric.get_by_id(rubric_id)
     if not rubric:
         return jsonify({"msg": "Rubric not found"}), 404
+
+    assignment = Assignment.get_by_id(rubric.assignmentID)
+    if not assignment:
+        return jsonify({"msg": "Assignment not found"}), 404
+    if not _can_view_assignment(assignment):
+        return jsonify({"msg": "Insufficient permissions"}), 403
 
     rubric_data = RubricSchema().dump(rubric)
     rubric_data["criteria_descriptions"] = CriteriaDescriptionSchema(many=True).dump(

--- a/flask_backend/api/controllers/submission_controller.py
+++ b/flask_backend/api/controllers/submission_controller.py
@@ -13,6 +13,7 @@ from .auth_controller import jwt_role_required, jwt_teacher_required
 from .helpers import get_authenticated_user
 
 bp = Blueprint("submission", __name__, url_prefix="/assignment")
+DEFAULT_MAX_SUBMISSION_FILE_SIZE_BYTES = 10 * 1024 * 1024
 
 
 def _normalize_original_name(filename):
@@ -60,6 +61,33 @@ def _extract_uploaded_submission_file():
             return uploaded_file
 
     return None
+
+
+def _read_submission_file_with_limit(uploaded_file):
+    max_file_size = int(
+        current_app.config.get(
+            "MAX_SUBMISSION_FILE_SIZE_BYTES",
+            DEFAULT_MAX_SUBMISSION_FILE_SIZE_BYTES,
+        )
+    )
+    content = uploaded_file.read(max_file_size + 1)
+    if not content:
+        return None, (jsonify({"msg": "Uploaded submission file is empty"}), 400)
+    if len(content) > max_file_size:
+        return (
+            None,
+            (
+                jsonify(
+                    {
+                        "msg": "Uploaded submission file exceeds maximum size",
+                        "max_size_bytes": max_file_size,
+                    }
+                ),
+                413,
+            ),
+        )
+
+    return content, None
 
 
 def _get_submission_storage_root():
@@ -201,9 +229,9 @@ def upload_submission(assignment_id):
     if not original_name:
         return jsonify({"msg": "Invalid file name"}), 400
 
-    content = uploaded_file.read()
-    if not content:
-        return jsonify({"msg": "Uploaded submission file is empty"}), 400
+    content, content_error = _read_submission_file_with_limit(uploaded_file)
+    if content_error:
+        return content_error
 
     stored_name = f"{uuid.uuid4().hex}__{original_name}"
     file_path = _get_submission_file_path(assignment.id, student.id, stored_name)

--- a/flask_backend/tests/conftest.py
+++ b/flask_backend/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from werkzeug.security import generate_password_hash
 
 from api import create_app
+from api.controllers import auth_controller
 from api.models import User, Course, User_Course
 from api.models.db import db as _db
 
@@ -54,6 +55,9 @@ def db(app):
     """Create a fresh database session for each test."""
     with app.app_context():
         _cleanup_assignment_upload_dirs(app)
+        auth_controller._failed_login_attempts.clear()
+        auth_controller._lockout_until.clear()
+        auth_controller._register_attempts.clear()
 
         # Clear all data from tables
         for table in reversed(_db.metadata.sorted_tables):
@@ -64,6 +68,9 @@ def db(app):
 
         # Cleanup after test
         _db.session.rollback()
+        auth_controller._failed_login_attempts.clear()
+        auth_controller._lockout_until.clear()
+        auth_controller._register_attempts.clear()
         _cleanup_assignment_upload_dirs(app)
 
 

--- a/flask_backend/tests/test_assignment_attachments.py
+++ b/flask_backend/tests/test_assignment_attachments.py
@@ -125,6 +125,43 @@ def test_teacher_can_add_attachment_after_assignment_creation(test_client, make_
     assert len(add_response.json["added_attachments"]) == 1
     assert add_response.json["added_attachments"][0]["original_name"] == "added-later.txt"
 
+
+def test_teacher_cannot_upload_oversized_attachment(test_client, make_admin):
+    make_admin(email="teacher-size@example.com", password="teacher", name="teacher-size")
+    test_client.application.config["MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES"] = 8
+
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "teacher-size@example.com", "password": "teacher"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    class_response = test_client.post(
+        "/class/create_class",
+        data=json.dumps({"name": "CompSci Size"}),
+        headers={"Content-Type": "application/json"},
+    )
+    class_id = class_response.json["class"]["id"]
+
+    create_response = test_client.post(
+        "/assignment/create_assignment",
+        data=json.dumps({
+            "courseID": str(class_id),
+            "name": "Oversized Attachment Assignment",
+        }),
+        headers={"Content-Type": "application/json"},
+    )
+    assignment_id = create_response.json["assignment"]["id"]
+
+    add_response = test_client.post(
+        f"/assignment/{assignment_id}/attachment",
+        data={"attachments": (io.BytesIO(b"0123456789"), "too-large.txt")},
+        content_type="multipart/form-data",
+    )
+
+    assert add_response.status_code == 413
+    assert "exceeds maximum size" in add_response.json["msg"]
+
 # This test verifies that a teacher can delete an attachment after the assignment has been created.
 def test_teacher_can_delete_attachment_after_assignment_creation(test_client, make_admin):
     make_admin(email="teacher6@example.com", password="teacher", name="teacheruser6")

--- a/flask_backend/tests/test_assignments.py
+++ b/flask_backend/tests/test_assignments.py
@@ -639,6 +639,47 @@ def test_unauthenticated_user_cannot_get_assignments(test_client):
     assignments = test_client.get(f"/assignment/1")
     assert assignments.status_code == 401
 
+
+def test_non_member_cannot_get_assignments_for_other_class(test_client, make_teacher):
+    """Ensure assignment lists are not exposed across classes to unrelated users."""
+    make_teacher(email="teacher1@example.com", password="teacher1", name="Teacher One")
+    make_teacher(email="teacher2@example.com", password="teacher2", name="Teacher Two")
+
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "teacher1@example.com", "password": "teacher1"}),
+        headers={"Content-Type": "application/json"},
+    )
+    class_response = test_client.post(
+        "/class/create_class",
+        data=json.dumps({"name": "Private Class"}),
+        headers={"Content-Type": "application/json"},
+    )
+    class_id = class_response.json["class"]["id"]
+    test_client.post(
+        "/assignment/create_assignment",
+        data=json.dumps(
+            {
+                "courseID": class_id,
+                "name": "Private Assignment",
+                "rubric": "Confidential",
+                "due_date": (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=10)).isoformat(),
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+
+    test_client.post("/auth/logout")
+    test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "teacher2@example.com", "password": "teacher2"}),
+        headers={"Content-Type": "application/json"},
+    )
+
+    response = test_client.get(f"/assignment/{class_id}")
+    assert response.status_code == 403
+    assert response.json["msg"] == "Insufficient permissions"
+
 # Test cases for assignments with start_date
 # pretty much just took one of the above test cases and added a start date line to it to check if it is stored correctly
 def test_teacher_can_create_assignment_with_start_date(test_client, make_admin):

--- a/flask_backend/tests/test_login.py
+++ b/flask_backend/tests/test_login.py
@@ -112,3 +112,112 @@ def test_logout(test_client):
     assert response.json["msg"] == "Successfully logged out"
     # Should clear the cookie
     assert "Set-Cookie" in response.headers
+
+
+def test_login_rate_limit_after_repeated_failures(test_client):
+    """Repeated bad passwords should trigger temporary lockout."""
+    test_client.post(
+        "/auth/register",
+        data=json.dumps(
+            {"name": "ratelimit-user", "password": "Password123!", "email": "ratelimit@example.com"}
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+
+    # First four failures stay as invalid credentials.
+    for _ in range(4):
+        response = test_client.post(
+            "/auth/login",
+            data=json.dumps({"email": "ratelimit@example.com", "password": "WrongPassword1!"}),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 401
+        assert response.json["msg"] == "Bad email or password"
+
+    # Fifth failure triggers lockout.
+    blocked_response = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "ratelimit@example.com", "password": "WrongPassword1!"}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert blocked_response.status_code == 429
+    assert "Too many failed login attempts" in blocked_response.json["msg"]
+    assert blocked_response.json["retry_after_seconds"] > 0
+
+    # Correct password is still blocked during lockout window.
+    locked_response = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "ratelimit@example.com", "password": "Password123!"}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert locked_response.status_code == 429
+
+
+def test_register_rate_limit_after_repeated_attempts(test_client):
+    test_client.application.config["REGISTER_ATTEMPT_MAX_ATTEMPTS"] = 3
+    test_client.application.config["REGISTER_ATTEMPT_WINDOW_SECONDS"] = 300
+
+    for idx in range(3):
+        response = test_client.post(
+            "/auth/register",
+            data=json.dumps(
+                {
+                    "name": f"testuser-{idx}",
+                    "password": "Password123!",
+                    "email": f"register-limit-{idx}@example.com",
+                }
+            ),
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 201
+
+    blocked = test_client.post(
+        "/auth/register",
+        data=json.dumps(
+            {
+                "name": "blocked-user",
+                "password": "Password123!",
+                "email": "register-limit-blocked@example.com",
+            }
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert blocked.status_code == 429
+    assert "Too many registration attempts" in blocked.json["msg"]
+    assert blocked.json["retry_after_seconds"] > 0
+
+
+def test_login_rate_limit_ignores_spoofed_forwarded_for_by_default(test_client):
+    test_client.application.config["LOGIN_ATTEMPT_MAX_FAILURES"] = 3
+    test_client.application.config["LOGIN_ATTEMPT_WINDOW_SECONDS"] = 300
+    test_client.application.config["LOGIN_LOCKOUT_SECONDS"] = 300
+    test_client.application.config["RATE_LIMIT_TRUST_PROXY_HEADERS"] = False
+
+    test_client.post(
+        "/auth/register",
+        data=json.dumps(
+            {"name": "spoof-user", "password": "Password123!", "email": "spoof@example.com"}
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+
+    response1 = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "spoof@example.com", "password": "WrongPassword1!"}),
+        headers={"Content-Type": "application/json", "X-Forwarded-For": "198.51.100.10"},
+    )
+    response2 = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "spoof@example.com", "password": "WrongPassword1!"}),
+        headers={"Content-Type": "application/json", "X-Forwarded-For": "198.51.100.11"},
+    )
+    response3 = test_client.post(
+        "/auth/login",
+        data=json.dumps({"email": "spoof@example.com", "password": "WrongPassword1!"}),
+        headers={"Content-Type": "application/json", "X-Forwarded-For": "198.51.100.12"},
+    )
+
+    assert response1.status_code == 401
+    assert response2.status_code == 401
+    assert response3.status_code == 429

--- a/flask_backend/tests/test_rubric.py
+++ b/flask_backend/tests/test_rubric.py
@@ -159,14 +159,36 @@ class TestCreateRubricAndAttachToAssignment:
 
         assert resp.status_code == 403
 
-    def test_get_rubric_for_nonexistent_assignment_returns_404(self, test_client):
+    def test_get_rubric_for_nonexistent_assignment_returns_404(self, test_client, make_admin):
         """
         GIVEN no rubric exists for assignment 9999
         WHEN GET /rubric/assignment/9999 is called
         THEN 404 is returned
         """
+        make_admin(email="teacher@example.com", password="pass", name="Teacher")
+        _login(test_client, "teacher@example.com", "pass")
+
         resp = test_client.get("/rubric/assignment/9999")
         assert resp.status_code == 404
+
+    def test_student_cannot_view_rubric_for_unenrolled_assignment(self, test_client, make_admin):
+        make_admin(email="teacher@example.com", password="pass", name="Teacher")
+        _login(test_client, "teacher@example.com", "pass")
+        course_id = _create_class(test_client, name="Restricted Course")
+        assignment_id = _create_assignment(test_client, course_id, assignment_mode="solo")
+        _create_rubric(test_client, assignment_id, rubric_type="peer")
+
+        test_client.post("/auth/logout")
+        test_client.post(
+            "/auth/register",
+            data=json.dumps({"name": "Student", "email": "student@example.com", "password": "Password1!"}),
+            headers={"Content-Type": "application/json"},
+        )
+        _login(test_client, "student@example.com", "Password1!")
+
+        resp = test_client.get(f"/rubric/assignment/{assignment_id}")
+        assert resp.status_code == 403
+        assert resp.get_json()["msg"] == "Insufficient permissions"
 
     def test_group_assignment_supports_separate_peer_and_group_rubrics(self, test_client, make_admin):
         make_admin(email="teacher@example.com", password="pass", name="Teacher")
@@ -361,22 +383,28 @@ class TestAddMultipleCriteria:
         assert resp.status_code == 404
         assert "not found for this assignment" in resp.get_json()["msg"].lower()
 
-    def test_get_criteria_with_non_integer_rubric_id_returns_400(self, test_client):
+    def test_get_criteria_with_non_integer_rubric_id_returns_400(self, test_client, make_admin):
         """
         GIVEN an invalid rubricID query parameter
         WHEN GET /criteria is called
         THEN the API returns a 400 instead of crashing
         """
+        make_admin(email="teacher@example.com", password="pass", name="Teacher")
+        _login(test_client, "teacher@example.com", "pass")
+
         resp = test_client.get("/criteria?rubricID=abc")
         assert resp.status_code == 400
         assert resp.get_json()["msg"] == "rubricID must be an integer"
 
-    def test_get_rubric_with_non_integer_rubric_id_returns_400(self, test_client):
+    def test_get_rubric_with_non_integer_rubric_id_returns_400(self, test_client, make_admin):
         """
         GIVEN an invalid rubricID query parameter
         WHEN GET /rubric is called
         THEN the API returns a 400 instead of crashing
         """
+        make_admin(email="teacher@example.com", password="pass", name="Teacher")
+        _login(test_client, "teacher@example.com", "pass")
+
         resp = test_client.get("/rubric?rubricID=xyz")
         assert resp.status_code == 400
         assert resp.get_json()["msg"] == "rubricID must be an integer"

--- a/flask_backend/tests/test_submission_upload.py
+++ b/flask_backend/tests/test_submission_upload.py
@@ -229,6 +229,32 @@ def test_teacher_cannot_upload_student_submission(test_client, make_teacher):
     assert upload_response.json["msg"] == "Insufficient permissions"
 
 
+def test_student_submission_rejects_oversized_file(
+    test_client,
+    make_teacher,
+    enroll_user_in_course,
+):
+    seeded = _seed_assignment_with_student(test_client, make_teacher, enroll_user_in_course)
+    test_client.application.config["MAX_SUBMISSION_FILE_SIZE_BYTES"] = 8
+
+    test_client.post(
+        "/auth/login",
+        data=json.dumps(
+            {"email": seeded["student_email"], "password": seeded["student_password"]}
+        ),
+        headers={"Content-Type": "application/json"},
+    )
+
+    upload_response = test_client.post(
+        f"/assignment/{seeded['assignment_id']}/submission",
+        data={"submission": (io.BytesIO(b"0123456789"), "too-large.txt")},
+        content_type="multipart/form-data",
+    )
+
+    assert upload_response.status_code == 413
+    assert "exceeds maximum size" in upload_response.json["msg"]
+
+
 def test_group_assignment_allows_only_one_submission_per_group(
     test_client,
     make_teacher,

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -35,7 +35,11 @@ export default function LoginPage() {
     } else {
       setError('Invalid email or password');
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && err.message.toLowerCase().includes('too many')) {
+      setError(err.message);
+      return;
+    }
     setError('Invalid email or password');
   }
 };

--- a/frontend/src/util/api.ts
+++ b/frontend/src/util/api.ts
@@ -30,8 +30,17 @@ export const tryLogin = async (email: string, password: string) => {
     });
     
     if (!response.ok) { 
-      // Throw if login fails for any reason
-      throw new Error(`Response status: ${response.status}`);
+      if (response.status === 429) {
+        const json = await response.json().catch(() => null);
+        const lockoutMessage =
+          typeof json?.msg === 'string'
+            ? json.msg
+            : 'Too many failed login attempts. Please try again later.';
+        throw new Error(lockoutMessage);
+      }
+
+      // Keep generic invalid-credential behavior for non-lockout failures.
+      return false;
     }
 
     const json = await response.json();
@@ -42,12 +51,9 @@ export const tryLogin = async (email: string, password: string) => {
 
     return json;
   } catch (error) {
-    // Login is wrong
     console.error(error);
-    // window.location.href = '/';
+    throw error;
   }
-
-  return false
 }
 
 export const tryRegister = async (name: string, email: string, password: string) => {


### PR DESCRIPTION
Introduce configurable protections and stricter access checks across the API:

- Add new app config options (MAX_SUBMISSION_FILE_SIZE_BYTES, MAX_ASSIGNMENT_ATTACHMENT_SIZE_BYTES, RATE_LIMIT_TRUST_PROXY_HEADERS, LOGIN_/REGISTER_ATTEMPT_* settings) in create_app.
- Implement server-side size checks for submission and assignment-attachment uploads; return 413 when files exceed limits and use safe read helpers to enforce limits.
- Add login/register throttling with in-memory counters, lockouts, and proxy-trust-aware client keying; return 429 on rate limit/lockout.
- Enforce course membership/permission checks for assignment and rubric endpoints and add jwt_required protections to rubric read endpoints.
- Update tests: add coverage for oversized uploads, login/register rate limits, permission checks, and ensure auth_controller state is cleared between tests.

These changes improve security (brute-force mitigation and upload abuse protection) and tighten authorization for assignment/rubric access.